### PR TITLE
793: Use v 1.2.7 of openbanking commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
-        <ob-clients.version>1.2.6</ob-clients.version>
-        <ob-common.version>1.2.6</ob-common.version>
+        <ob-clients.version>1.2.7</ob-clients.version>
+        <ob-common.version>1.2.7</ob-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
https://github.com/OpenBankingToolkit/openbanking-common/releases/tag/1.2.7

Fixes;
Serialisation is based on the value of the `iss` field of the software
statement, and the code expected OpenBanking iss to be "OpenBanking",
however in OB Directory Issued Software Statements the iss field is
actually "OpenBanking Ltd"

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793