### PR TITLE
793: Fix more issues with DirectorySoftwareStatement serialisation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
-        <ob-clients.version>1.2.8</ob-clients.version>
-        <ob-common.version>1.2.8</ob-common.version>
+        <ob-clients.version>1.2.9</ob-clients.version>
+        <ob-common.version>1.2.9</ob-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140