### PR TITLE
Release 1.1.9 with 796: add matls checks to dcr code

### DIFF
--- a/forgerock-openbanking-auth/pom.xml
+++ b/forgerock-openbanking-auth/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-auth</artifactId>
-        <version>1.1.9</version>
+        <version>1.1.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-auth/pom.xml
+++ b/forgerock-openbanking-auth/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-auth</artifactId>
-        <version>1.1.9-SNAPSHOT</version>
+        <version>1.1.9</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
-        <ob-clients.version>1.2.9</ob-clients.version>
-        <ob-common.version>1.2.9</ob-common.version>
+        <ob-clients.version>1.2.10</ob-clients.version>
+        <ob-common.version>1.2.10</ob-common.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - auths</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-auth</artifactId>
-    <version>1.1.9</version>
+    <version>1.1.10-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -145,7 +145,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-auth.git</url>
-        <tag>1.1.9</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - auths</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-auth</artifactId>
-    <version>1.1.9-SNAPSHOT</version>
+    <version>1.1.9</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -145,7 +145,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-auth.git</url>
-        <tag>HEAD</tag>
+        <tag>1.1.9</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
796: Add MATLS checks to DCR code

Common code needed to perform MATLS checks to ensure the MATLS transport
cert presented for registration and the software statement being used
for registration were issed to the same ApiClient (TPP)

Issue: https://github.com/ForgeCloud/ob-deploy/issues/796