### PR TITLE
Release 1.1.11 - use latests parent and commons

### DIFF
--- a/forgerock-openbanking-auth/pom.xml
+++ b/forgerock-openbanking-auth/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-auth</artifactId>
-        <version>1.1.11</version>
+        <version>1.1.12-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - auths</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-auth</artifactId>
-    <version>1.1.11</version>
+    <version>1.1.12-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -145,7 +145,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-auth.git</url>
-        <tag>1.1.11</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Use latest parent and commons;

Allow creation of OBRIRoles from PSD2Role
Also;
Pulls in 1.0.3 of spring-security-mult-auth that has improved logging

Issue: https://github.com/ForgeCloud/ob-deploy/issues/802