### PR TITLE
965: Accept new OpenBanking SSAs and release 1.5.3

### DIFF
--- a/forgerock-openbanking-auth/pom.xml
+++ b/forgerock-openbanking-auth/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-auth</artifactId>
-        <version>1.5.3-SNAPSHOT</version>
+        <version>1.5.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-auth/pom.xml
+++ b/forgerock-openbanking-auth/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-auth</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - auths</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-auth</artifactId>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.5.3</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -145,7 +145,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-auth.git</url>
-        <tag>HEAD</tag>
+        <tag>1.5.3</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
-        <ob-clients.version>1.5.2</ob-clients.version>
-        <ob-common.version>1.5.2</ob-common.version>
+        <ob-clients.version>1.5.3</ob-clients.version>
+        <ob-common.version>1.5.3</ob-common.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - auths</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-auth</artifactId>
-    <version>1.5.3</version>
+    <version>1.5.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -145,7 +145,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-auth.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-auth.git</url>
-        <tag>1.5.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Open Banking SSAs have software_version as a string rather than a double

Issue: https://github.com/forgecloud/ob-deploy/issues/965 